### PR TITLE
fix: apply natural sorting for item names

### DIFF
--- a/frontend/components/Item/View/Table.vue
+++ b/frontend/components/Item/View/Table.vue
@@ -249,13 +249,17 @@
       return 0;
     }
 
-    const aLower = extractSortable(a, sortByProperty.value);
-    const bLower = extractSortable(b, sortByProperty.value);
+    const aVal = extractSortable(a, sortByProperty.value);
+    const bVal = extractSortable(b, sortByProperty.value);
 
-    if (aLower < bLower) {
+    if (typeof aVal === "string" && typeof bVal === "string") {
+      return aVal.localeCompare(bVal, undefined, { numeric: true, sensitivity: "base" });
+    }
+
+    if (aVal < bVal) {
       return -1;
     }
-    if (aLower > bLower) {
+    if (aVal > bVal) {
       return 1;
     }
     return 0;


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixes incorrect sorting of item names like `Box 1`, `Box 10`, `Box 2`, etc.  
Previously, items were sorted lexicographically, which led to unintuitive ordering.

**Changes:**
- Updated `itemSort` function in `Item/View/Table.vue`
- Uses `localeCompare(..., { numeric: true })` for natural sorting of strings

Fixes incorrect sorting of item names like `Box 1`, `Box 10`, `Box 2`, etc.  
Previously, items were sorted lexicographically, which led to unintuitive ordering.

## Which issue(s) this PR fixes:

Fixes #606

## Special notes for your reviewer:

Focus is on the `itemSort` function logic, i dunno what to say...haha

## Testing

Tested manually by creating items with names like:
- `Box 1`, `Box 2`, `Box 10`

Verified that sorting order is now correct and intuitive in the UI.
